### PR TITLE
Bump version to 2.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tineye-api",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "TinEye API node.js library",
   "keywords": [
     "TinEye",


### PR DESCRIPTION
The tar uploaded to npm was corrupted in some way.

In order to correct it I had to yank the release but you cannot reuse the version.

This bumps the version to 2.0.6 to reflect the version in NPM